### PR TITLE
Fix auth not working on deployed app

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "swr": "^2.3.6",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
-    "typescript-cookie": "^1.0.6",
     "vaul": "^0.9.9",
     "zod": "^3.25.76"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,9 +176,6 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.17)
-      typescript-cookie:
-        specifier: ^1.0.6
-        version: 1.0.6
       vaul:
         specifier: ^0.9.9
         version: 0.9.9(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2598,10 +2595,6 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  typescript-cookie@1.0.6:
-    resolution: {integrity: sha512-s+BZr7/9BUG6Kg7jGGcOY/4XJcP+iZRFdF3q4FPTfRSP83ivLWF94OcH8PrzGmnS8Ab9qP7ENu/ikLwNFsIafA==}
-    engines: {node: '>=14'}
-
   typescript-eslint@8.40.0:
     resolution: {integrity: sha512-Xvd2l+ZmFDPEt4oj1QEXzA4A2uUK6opvKu3eGN9aGjB8au02lIVcLyi375w94hHyejTOmzIU77L8ol2sRg9n7Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -4962,8 +4955,6 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  typescript-cookie@1.0.6: {}
 
   typescript-eslint@8.40.0(eslint@9.34.0(jiti@1.21.7))(typescript@5.9.2):
     dependencies:

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -172,3 +172,19 @@ export async function verifyEmail(token: string) {
 		};
 	}
 }
+
+/**
+ * @returns true if client is authenticated, false if not authenticated
+ * @throws {statusCode, message} if response's status code is not 200 or 401
+ */
+export async function isClientAuthenticated() {
+	try {
+		const response = await httpClient.get("/auth/check");
+		return response.data.data.loggedIn;
+	} catch (error) {
+		throw {
+			statusCode: error.status,
+			message: error.data?.message || "Auth check failed"
+		}
+	}
+}

--- a/src/context/authentication/AuthContextProvider.tsx
+++ b/src/context/authentication/AuthContextProvider.tsx
@@ -1,10 +1,9 @@
-import { useCallback, useState } from "react";
-import { logOut as apiLogOut, login as apiLogin } from "@/api/auth.api";
+import { useCallback, useEffect, useState } from "react";
+import { logOut as apiLogOut, login as apiLogin, isClientAuthenticated } from "@/api/auth.api";
 import { googleLogout } from "@react-oauth/google";
 import AuthContext from "./AuthContext";
 import { httpClient } from "@/api/api";
 import useSWR from "swr";
-import { getCookie } from "typescript-cookie";
 
 /**
  * Fetches the profile of the currently authenticated user
@@ -30,13 +29,17 @@ interface AuthContextProviderProps {
 // isLoading is true when the request is in flight for the first time (user is null)
 // isValidating is true when the request is in flight and during revalidation (user can be non-null)
 export default function AuthContextProvider({ children }: AuthContextProviderProps) {
-    const [loggedIn, setLoggedIn] = useState(getCookie("logged_in") === "true");
+    const [loggedIn, setLoggedIn] = useState(false);
     const {
 		mutate,
 		data: user,
 		isValidating,
 		isLoading,
 	} = useSWR(loggedIn ? "/user/profile" : null, fetcher);
+
+    useEffect(() => {
+        isClientAuthenticated().then(status => setLoggedIn(status))
+    }, []);
 
     const logIn = useCallback(
         async (emailOrMatricNo: string, password: string) => {


### PR DESCRIPTION
The issue stemmed from the client not being able to access a cookie set by the backend due to them being hosted on different domains.

The cookie was for knowing if the client was logged in or not

There were 2 possible fixes:
- Changing the domain that is set on the cookie to the frontend's domain
- Checking the user's authentication status on mount and updating the logged in state.

I went with the alternative approach